### PR TITLE
Don't autoload class_exists

### DIFF
--- a/Postmark.php
+++ b/Postmark.php
@@ -62,7 +62,7 @@ class Mail_Postmark
 	*/
 	public function __construct()
 	{
-		if (class_exists('Mail_Postmark_Adapter')) {
+		if (class_exists('Mail_Postmark_Adapter', false)) {
 			require_once('Adapter_Interface.php');
 			
 			$reflection = new ReflectionClass('Mail_Postmark_Adapter');
@@ -504,7 +504,7 @@ class Mail_Postmark
 	*/
 	private function _log($logData)
 	{
-		if (class_exists('Mail_Postmark_Adapter')) {
+		if (class_exists('Mail_Postmark_Adapter', false)) {
 			Mail_Postmark_Adapter::log($logData);
 		}
 	}


### PR DESCRIPTION
As per https://github.com/Znarkus/postmark-php/issues/11

I spent a while tracking this down, then eventually came across the issue which has already been reported. Due to the common use of autoloaders, I think it would save others much debugging time if we just incorporated this very simple fix.

Much love from GoSquared.
