### PR TITLE
Explicit namespace declaration

### DIFF
--- a/src/Postmark/Mail.php
+++ b/src/Postmark/Mail.php
@@ -56,7 +56,7 @@ class Mail
 		if (class_exists('Mail_Postmark_Adapter', false)) {
 			$reflection = new ReflectionClass('Mail_Postmark_Adapter');
 
-			if (!$reflection->implementsInterface('MailAdapterInterface')) {
+			if (!$reflection->implementsInterface('\\PostMark\\MailAdapterInterface')) {
 				trigger_error('Mail_Postmark_Adapter must implement interface MailAdapterInterface', E_USER_ERROR);
 			}
 


### PR DESCRIPTION
Namespace needs to be explicitly declared when using
ReflectionClass::implementsInterface
