### PR TITLE
Added reset method

### DIFF
--- a/src/Postmark/Mail.php
+++ b/src/Postmark/Mail.php
@@ -365,6 +365,20 @@ class Mail
 	}
 
 	/**
+	 * Resets recipients for an email to allow this reference to be used more
+	 * than once
+	 *
+	 * @param string $subject E-mail subject
+	 * @return Mail
+	 */
+	public function reset()
+	{
+		$this->_to = array();
+		$this->_cc = array();
+		$this->_bcc = array();
+	}
+
+	/**
 	 * Specify subject
 	 *
 	 * @param string $subject E-mail subject


### PR DESCRIPTION
To preserve memory, it's useful to reuse a Mail reference
However doing so can cause recipients to spill over
eg. when using the `addTo` method, any previously added recipients would continue to be sent the next piece of mail
Adding the ability to reset these arrays makes the process easier
